### PR TITLE
Add role support and linter validation

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -55,9 +55,11 @@ func LintSpecFile(source []byte) LintResult {
 	usedAgents := map[string]bool{}
 	referencedAgents := map[string]bool{}
 	definedAgents := map[string]*yaml.Node{}
+	definedRoles := map[string]bool{}
 
 	// Locate top-level "agents" mapping with defensive traversal
 	var agentsNode *yaml.Node
+	var rolesNode *yaml.Node
 	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
 		rootMap := root.Content[0]
 		if rootMap.Kind == yaml.MappingNode {
@@ -65,7 +67,9 @@ func LintSpecFile(source []byte) LintResult {
 				keyNode := rootMap.Content[i]
 				if keyNode.Value == "agents" {
 					agentsNode = rootMap.Content[i+1]
-					break
+				}
+				if keyNode.Value == "roles" {
+					rolesNode = rootMap.Content[i+1]
 				}
 			}
 		}
@@ -99,6 +103,14 @@ func LintSpecFile(source []byte) LintResult {
 		definedAgents[name] = agentValueNode
 	}
 
+	// Collect all defined roles
+	if rolesNode != nil && rolesNode.Kind == yaml.MappingNode {
+		for i := 0; i < len(rolesNode.Content)-1; i += 2 {
+			roleName := rolesNode.Content[i].Value
+			definedRoles[roleName] = true
+		}
+	}
+
 	// Regex to find .Get "agentname" and .Start "agentname"
 	referenceRegex := regexp.MustCompile(`\.(Get|Start)\s+"([^"]+)"`)
 
@@ -110,6 +122,9 @@ func LintSpecFile(source []byte) LintResult {
 		var inputsNode *yaml.Node
 		var listenersNode *yaml.Node
 		var factsNode *yaml.Node
+		var roleName string
+		var roleLine int
+		var aliasName string
 		for i := 0; i < len(node.Content)-1; i += 2 {
 			key := node.Content[i].Value
 			val := node.Content[i+1]
@@ -130,6 +145,9 @@ func LintSpecFile(source []byte) LintResult {
 				}
 				if key == "alias" && val.Value == name {
 					errors = append(errors, fmt.Sprintf("Problem: Line %d: Agent '%s' is an alias that references itself. This creates an infinite loop.", val.Line, name))
+				}
+				if key == "alias" {
+					aliasName = val.Value
 				}
 			case "description":
 				hasDescription = true
@@ -165,6 +183,9 @@ func LintSpecFile(source []byte) LintResult {
 						}
 					}
 				}
+			case "role":
+				roleName = val.Value
+				roleLine = val.Line
 			}
 		}
 
@@ -216,6 +237,28 @@ func LintSpecFile(source []byte) LintResult {
 			// Only add warning if agent is used as a listener
 			if usedAgents[name] {
 				warnings = append(warnings, fmt.Sprintf("Reminder: Line %d: Agent '%s' is missing a description. Consider adding a description to clarify the agent's purpose.", node.Line, name))
+			}
+		}
+
+		if roleName != "" {
+			if !definedRoles[roleName] {
+				errors = append(errors, fmt.Sprintf("Problem: Line %d: Agent '%s' references undefined role '%s'.", roleLine, name, roleName))
+			}
+			if kindSet["template"] || kindSet["function"] {
+				warnings = append(warnings, fmt.Sprintf("Reminder: Line %d: Agent '%s' assigns role '%s' but roles only affect prompt agents.", roleLine, name, roleName))
+			} else if kindSet["alias"] {
+				if aliasNode, ok := definedAgents[aliasName]; ok {
+					aliasKinds := map[string]bool{}
+					for j := 0; j < len(aliasNode.Content)-1; j += 2 {
+						k := aliasNode.Content[j].Value
+						if k == "template" || k == "function" {
+							aliasKinds[k] = true
+						}
+					}
+					if aliasKinds["template"] || aliasKinds["function"] {
+						warnings = append(warnings, fmt.Sprintf("Reminder: Line %d: Agent '%s' assigns role '%s' to alias '%s' which is not a prompt agent.", roleLine, name, roleName, aliasName))
+					}
+				}
 			}
 		}
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -418,3 +418,50 @@ agents:
 		t.Error("Expected schema validation error")
 	}
 }
+
+func TestLintSpecFile_RoleWarnings(t *testing.T) {
+	yaml := `---
+agents:
+  a:
+    description: templ agent
+    template: |
+      hi
+    role: r1
+roles:
+  r1:
+    description: role one
+`
+	result := LintSpecFile([]byte(yaml))
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning for role on template agent")
+	}
+	if !result.Valid {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+}
+
+func TestLintSpecFile_RoleUndefined(t *testing.T) {
+	yaml := `---
+agents:
+  a:
+    description: prompt agent
+    prompt: hello
+    role: missing
+roles:
+  r1:
+    description: role one
+`
+	result := LintSpecFile([]byte(yaml))
+	if result.Valid {
+		t.Error("expected invalid spec due to undefined role")
+	}
+	found := false
+	for _, err := range result.Errors {
+		if strings.Contains(err, "undefined role") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected undefined role error, got %v", result.Errors)
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -452,7 +452,7 @@ func (r *RunContext) parseAgentFacts(agent *agents.Agent, role *agents.AgentRole
 		}
 	}
 	if role != nil && role.Facts != nil {
-		for k, arg := range agent.Facts {
+		for k, arg := range role.Facts {
 			if arg.Scope == "local" {
 				localMap[k] = factMap[k]
 				delete(factMap, k)
@@ -620,22 +620,46 @@ note: Have a nice day.
 		return err
 	}
 	for k, v := range factMap {
-		name := k
-		if !strings.Contains(k, ".") {
-			// already qualified
-			name = fmt.Sprintf("%s.%s", agent.Name, k)
+		if _, ok := agent.Facts[k]; ok {
+			name := k
+			if !strings.Contains(k, ".") {
+				name = fmt.Sprintf("%s.%s", agent.Name, k)
+			}
+			r.AssignFact(agent, name, v)
+			r.Card.Facts[name] = v
+			continue
 		}
-		r.AssignFact(agent, name, v)
-		r.Card.Facts[name] = v
+		if role != nil && role.Facts != nil {
+			if _, ok := role.Facts[k]; ok {
+				name := k
+				if !strings.Contains(k, ".") {
+					name = fmt.Sprintf("%s.%s", role.ID, k)
+				}
+				r.AssignRoleFact(role, name, v)
+				r.Card.Facts[name] = v
+			}
+		}
 	}
 	for k, v := range localMap {
-		name := k
-		if !strings.Contains(k, ".") {
-			// already qualified
-			name = fmt.Sprintf("%s.%s", agent.Name, k)
+		if _, ok := agent.Facts[k]; ok {
+			name := k
+			if !strings.Contains(k, ".") {
+				name = fmt.Sprintf("%s.%s", agent.Name, k)
+			}
+			r.AssignLocalFact(agent, name, v)
+			r.Card.LocalFacts[name] = v
+			continue
 		}
-		r.AssignLocalFact(agent, name, v)
-		r.Card.LocalFacts[name] = v
+		if role != nil && role.Facts != nil {
+			if _, ok := role.Facts[k]; ok {
+				name := k
+				if !strings.Contains(k, ".") {
+					name = fmt.Sprintf("%s.%s", role.ID, k)
+				}
+				r.AssignRoleLocalFact(role, name, v)
+				r.Card.LocalFacts[name] = v
+			}
+		}
 	}
 	return nil
 }
@@ -845,6 +869,82 @@ func (r *RunContext) AssignLocalFact(agent *agents.Agent, name string, v any) {
 		r.LocalFacts = make(map[string]any)
 	}
 	fact := agent.Facts[name]
+	if existing, ok := r.LocalFacts[name]; ok && fact != nil && fact.Add {
+		switch val := existing.(type) {
+		case []any:
+			r.LocalFacts[name] = append(val, v)
+		case string:
+			r.LocalFacts[name] = fmt.Sprintf("%s\n%s", val, v)
+		case int:
+			switch v2 := v.(type) {
+			case int:
+				r.LocalFacts[name] = val + v2
+			case float64:
+				r.LocalFacts[name] = float64(val) + v2
+			default:
+				r.LocalFacts[name] = v
+			}
+		case float64:
+			switch v2 := v.(type) {
+			case int:
+				r.LocalFacts[name] = val + float64(v2)
+			case float64:
+				r.LocalFacts[name] = val + v2
+			default:
+				r.LocalFacts[name] = v2
+			}
+		default:
+			r.LocalFacts[name] = v
+		}
+	} else {
+		r.LocalFacts[name] = v
+	}
+}
+
+// AssignRoleFact assigns or updates a fact in the chat's Facts map according to the role's Fact definition.
+func (r *RunContext) AssignRoleFact(role *agents.AgentRole, name string, v any) {
+	if r.Chat == nil {
+		return
+	}
+	fact := role.Facts[name]
+	if existing, ok := r.Chat.Facts[name]; ok && fact != nil && fact.Add {
+		switch val := existing.(type) {
+		case []any:
+			r.Chat.Facts[name] = append(val, v)
+		case string:
+			r.Chat.Facts[name] = fmt.Sprintf("%s\n%s", val, v)
+		case int:
+			switch v2 := v.(type) {
+			case int:
+				r.Chat.Facts[name] = val + v2
+			case float64:
+				r.Chat.Facts[name] = float64(val) + v2
+			default:
+				r.Chat.Facts[name] = v
+			}
+		case float64:
+			switch v2 := v.(type) {
+			case int:
+				r.Chat.Facts[name] = val + float64(v2)
+			case float64:
+				r.Chat.Facts[name] = val + v2
+			default:
+				r.Chat.Facts[name] = v2
+			}
+		default:
+			r.Chat.Facts[name] = v
+		}
+	} else {
+		r.Chat.Facts[name] = v
+	}
+}
+
+// AssignRoleLocalFact assigns or updates a local fact in the RunContext's LocalFacts map according to the role's Fact definition.
+func (r *RunContext) AssignRoleLocalFact(role *agents.AgentRole, name string, v any) {
+	if r.LocalFacts == nil {
+		r.LocalFacts = make(map[string]any)
+	}
+	fact := role.Facts[name]
 	if existing, ok := r.LocalFacts[name]; ok && fact != nil && fact.Add {
 		switch val := existing.(type) {
 		case []any:

--- a/spec_schema.json
+++ b/spec_schema.json
@@ -85,6 +85,47 @@
             ]
           }
         }
+      },
+      "roles": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "description": { "type": "string" },
+            "personality": { "type": "string" },
+            "performance": { "type": "string" },
+            "inputs": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "description": { "type": "string" },
+                  "type": { "type": "string" },
+                  "name": { "type": "string" }
+                },
+                "required": ["description"]
+              }
+            },
+            "facts": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "description": { "type": "string" },
+                  "scope": { "type": "string", "enum": ["global", "local"] },
+                  "type": { "type": "string" },
+                  "tags": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "add": { "type": "boolean" }
+                },
+                "required": ["description"]
+              }
+            }
+          },
+          "required": []
+        }
       }
     },
     "required": ["agents"]


### PR DESCRIPTION
## Summary
- implement role fact parsing and storage
- add role-aware fact assignment helpers
- extend linter to validate roles and warn when unused on template/function agents
- include roles in spec schema
- add tests for role linting

## Testing
- `go test ./...` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c45d3d9388324bb18ba851ebb4a9e