### PR TITLE
Add loadfacts API to replace chat facts

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -59,6 +59,14 @@ func (c *Chat) Fact(name string) any {
 	return nil
 }
 
+// LoadFacts replaces the chat's facts map with the provided one.
+func (c *Chat) LoadFacts(facts map[string]any) {
+	if c == nil {
+		return
+	}
+	c.Facts = facts
+}
+
 func (c *Chat) NewRegistry(spec string) (*Registry, error) {
 	reg, err := NewRegistry(spec)
 	if err != nil {
@@ -237,6 +245,26 @@ func FactsHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "failed to encode facts", http.StatusInternalServerError)
 	}
+}
+
+// LoadFactsHandler replaces the chat facts with the provided map.
+func LoadFactsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		Facts map[string]any `json:"facts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if defaultChat == nil {
+		defaultChat = NewChat("")
+	}
+	defaultChat.LoadFacts(payload.Facts)
+	w.WriteHeader(http.StatusOK)
 }
 
 // ExtractYAMLFromMarkdown locates a ```yaml ... ``` block and extracts its content.

--- a/loadfacts_test.go
+++ b/loadfacts_test.go
@@ -1,0 +1,39 @@
+package agencia
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoadFactsHandler(t *testing.T) {
+	defaultChat = NewChat("test")
+	defaultChat.Facts["old"] = "value"
+
+	payload := map[string]any{
+		"facts": map[string]any{
+			"new": "fact",
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/loadfacts", bytes.NewReader(data))
+	w := httptest.NewRecorder()
+	LoadFactsHandler(w, req)
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected status OK, got %v", res.Status)
+	}
+	if _, ok := defaultChat.Facts["old"]; ok {
+		t.Fatalf("expected old facts to be replaced")
+	}
+	if v, ok := defaultChat.Facts["new"]; !ok || v != "fact" {
+		t.Fatalf("expected new fact to be loaded, got %v", defaultChat.Facts)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -45,6 +45,7 @@ func Server(ctx context.Context, url string) {
 	http.HandleFunc("/api/run", handleRun)
 	http.HandleFunc("/api/chat", ChatWebSocketHandler)
 	http.HandleFunc("/api/facts", FactsHandler)
+	http.HandleFunc("/api/loadfacts", LoadFactsHandler)
 
 	log.Fatal(http.ListenAndServe(url, nil))
 }


### PR DESCRIPTION
## Summary
- add `LoadFacts` method and HTTP handler to replace chat facts
- expose `/api/loadfacts` endpoint
- cover handler with unit test

## Testing
- `go test ./...` *(fails: OPENAI_API_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688ffb41e21c832493ef355f5fc6e041