### PR TITLE
feat: support chat observations

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -63,6 +63,29 @@ func (c *Chat) LoadFacts(facts map[string]any) {
 	c.Facts = facts
 }
 
+// AddObservation stores an observation for the given role and key.
+// Observations are unstructured pieces of knowledge gathered during chat.
+func (c *Chat) AddObservation(role, key, observation string) {
+	if c == nil {
+		return
+	}
+	if c.Observations == nil {
+		c.Observations = make(map[string]map[string][]string)
+	}
+	if _, ok := c.Observations[role]; !ok {
+		c.Observations[role] = make(map[string][]string)
+	}
+	c.Observations[role][key] = append(c.Observations[role][key], observation)
+}
+
+// ObservationsByRole returns the observations for the specified role.
+func (c *Chat) ObservationsByRole(role string) map[string][]string {
+	if c == nil {
+		return nil
+	}
+	return c.Observations[role]
+}
+
 func (c *Chat) NewRegistry(spec string) (*Registry, error) {
 	reg, err := NewRegistry(spec)
 	if err != nil {
@@ -229,8 +252,8 @@ func (r *RunContext) ExtractAgentMemory(ctx context.Context, agent *agents.Agent
 func FactsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(map[string]any{
-		"facts": defaultChat.Facts,
-		// "Observations": defaultChat.Observations,
+		"facts":        defaultChat.Facts,
+		"observations": defaultChat.Observations,
 	})
 	if err != nil {
 		http.Error(w, "failed to encode facts", http.StatusInternalServerError)

--- a/chat_test.go
+++ b/chat_test.go
@@ -93,3 +93,12 @@ agents:
 	assert.Equal(t, "helper", trace.AgentName, "chat start agent should helper")
 	assert.Equal(t, "Helper heard: second", strings.TrimSpace(out2))
 }
+
+func TestChatAddObservation(t *testing.T) {
+	chat := NewChat("test")
+	chat.AddObservation("writer", "preference", "prefers novels to short stories")
+
+	obs := chat.ObservationsByRole("writer")
+	require.NotNil(t, obs)
+	assert.Equal(t, []string{"prefers novels to short stories"}, obs["preference"])
+}

--- a/docs/agencia.md
+++ b/docs/agencia.md
@@ -178,9 +178,10 @@ in the context.  But if you do that, these are no longer pure functions.
 
 ## 5. Agencia Chat
 
-The chat represents all ephemeral state including, Facts, and Observations.  Facts are structured
-knowledge and Observations are unstructured knowledge.  Observations and their associated Roles,
-are not yet part of Agencia.  Stay tuned.
+The chat represents all ephemeral state including Facts and Observations. Facts are structured
+knowledge and observations are unstructured knowledge gathered according to an agent's roles.
+Each role can declare observations that describe the kind of information to collect, and the chat
+stores the summarized results by role for future use.
 
 ### 5.1 Remembering Facts in Chat
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -465,3 +465,29 @@ roles:
 		t.Errorf("expected undefined role error, got %v", result.Errors)
 	}
 }
+
+func TestLintSpecFile_RoleObservations(t *testing.T) {
+	yaml := `---
+agents:
+  a:
+    description: prompt agent
+    prompt: hello
+    role: r1
+roles:
+  r1:
+    description: role one
+    observations:
+      writing_pref: look for writing preferences
+`
+	result := LintSpecFile([]byte(yaml))
+	if !result.Valid {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	spec, err := loadAgentSpec([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected spec load error: %v", err)
+	}
+	if got := spec.Roles["r1"].Observations["writing_pref"]; got != "look for writing preferences" {
+		t.Errorf("unexpected observation description: %v", got)
+	}
+}

--- a/spec_schema.json
+++ b/spec_schema.json
@@ -122,6 +122,10 @@
                 },
                 "required": ["description"]
               }
+            },
+            "observations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
             }
           },
           "required": []


### PR DESCRIPTION
## Summary
- track unstructured observations in chat and expose them via the API
- allow roles to define observation prompts in specs
- document and test observation support

## Testing
- `go test ./...` *(fails: OPENAI_API_KEY must be set)*
- `go test -run TestChatAddObservation -count=1`
- `go test -run TestLintSpecFile_RoleObservations -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6891241451a883248d75c2eb18123d1b