### PR TITLE
Implement role-based observation gathering for prompt agents

### DIFF
--- a/observations.go
+++ b/observations.go
@@ -1,0 +1,112 @@
+package agencia
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/robbyriverside/agencia/agents"
+)
+
+// observationAICall allows tests to stub AI calls.
+var observationAICall = agents.CallOpenAI
+
+// gatherObservationsFromInput asks AI to synthesize observations from the input
+// according to the role's observation descriptions.
+func (r *RunContext) gatherObservationsFromInput(ctx context.Context, role *agents.AgentRole, input string) (map[string][]string, error) {
+	if role == nil || len(role.Observations) == 0 {
+		return nil, nil
+	}
+	var b strings.Builder
+	b.WriteString("Input:\n" + input + "\n\n")
+	b.WriteString("For each of the following observation keys, extract zero or more observations as short active sentences. Avoid using the exact wording from the input. Return JSON mapping keys to arrays of observations.\n\n")
+	b.WriteString("Observations:\n")
+	for k, v := range role.Observations {
+		b.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+	}
+	b.WriteString("\nRespond with JSON only.")
+
+	prompt := b.String()
+	resp, err := observationAICall(ctx, prompt)
+	if err != nil {
+		return nil, err
+	}
+	obs := make(map[string][]string)
+	if err := json.Unmarshal([]byte(resp), &obs); err != nil {
+		return nil, fmt.Errorf("unmarshal observations JSON: %w. response: %s. prompt: %s", err, resp, prompt)
+	}
+	return obs, nil
+}
+
+// mergeObservations combines existing and new observations using AI to remove duplicates.
+func (r *RunContext) mergeObservations(ctx context.Context, existing, incoming map[string][]string) (map[string][]string, error) {
+	if len(incoming) == 0 {
+		return existing, nil
+	}
+	existingJSON, _ := json.Marshal(existing)
+	incomingJSON, _ := json.Marshal(incoming)
+
+	prompt := fmt.Sprintf("Existing observations: %s\nNew observations: %s\nAdd the new observations to the existing ones without creating redundant meaning or duplicates. Return only the combined observations as JSON.", existingJSON, incomingJSON)
+	resp, err := observationAICall(ctx, prompt)
+	if err != nil {
+		return nil, err
+	}
+	merged := make(map[string][]string)
+	if err := json.Unmarshal([]byte(resp), &merged); err != nil {
+		return nil, fmt.Errorf("unmarshal merged observations JSON: %w. response: %s. prompt: %s", err, resp, prompt)
+	}
+	return merged, nil
+}
+
+// buildObservationPrompt builds a sub-prompt string from observations.
+func buildObservationPrompt(role string, obs map[string][]string) string {
+	if len(obs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Use the following observations gathered for your role when responding.\n")
+	for k, list := range obs {
+		if len(list) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("%s:\n", k))
+		for _, o := range list {
+			b.WriteString("- " + o + "\n")
+		}
+	}
+	return b.String()
+}
+
+// processObservations orchestrates gathering, merging, storing, and prompt creation.
+func (r *RunContext) processObservations(ctx context.Context, agent *agents.Agent, input string) (string, error) {
+	if r == nil || r.Registry == nil || r.Chat == nil || agent == nil || agent.Role == "" {
+		return "", nil
+	}
+	role, ok := r.Registry.LookupRole(agent.Role)
+	if !ok || len(role.Observations) == 0 {
+		return "", nil
+	}
+
+	newObs, err := r.gatherObservationsFromInput(ctx, role, input)
+	if err != nil {
+		r.Errorf("gather observations error: %v", err)
+		return "", nil
+	}
+	existing := r.Chat.ObservationsByRole(role.ID)
+	merged, err := r.mergeObservations(ctx, existing, newObs)
+	if err != nil {
+		r.Errorf("merge observations error: %v", err)
+		// fall back to naive merge
+		merged = existing
+		for k, list := range newObs {
+			merged[k] = append(merged[k], list...)
+		}
+	}
+	if r.Chat.Observations == nil {
+		r.Chat.Observations = make(map[string]map[string][]string)
+	}
+	r.Chat.Observations[role.ID] = merged
+
+	return buildObservationPrompt(role.ID, merged), nil
+}

--- a/run.go
+++ b/run.go
@@ -326,6 +326,7 @@ func (r *RunContext) execTemplateAgent(ctx context.Context, agent *agents.Agent,
 
 func (r *RunContext) execPromptAgent(ctx context.Context, agent *agents.Agent, input string, name string) AgentResult {
 	template := agent.Prompt
+	var obsPrompt string
 	if agent.Role != "" {
 		role, ok := r.Registry.LookupRole(agent.Role)
 		if ok && role.Description != "" || role.Personality != "" || role.Performance != "" {
@@ -339,10 +340,18 @@ func (r *RunContext) execPromptAgent(ctx context.Context, agent *agents.Agent, i
 				template = fmt.Sprintf("%s\n\nYou Are Playing: %s\n%s%s", template, role.ID, personality, performance)
 			}
 		}
+		var err error
+		obsPrompt, err = r.processObservations(ctx, agent, input)
+		if err != nil {
+			r.Errorf("observation processing error: %v", err)
+		}
 	}
 	finalPrompt, err := r.renderFinalPrompt(ctx, template, agent, input)
 	if err != nil {
 		return AgentResult{Ran: false, Error: err, AgentName: name}
+	}
+	if obsPrompt != "" {
+		finalPrompt = obsPrompt + "\n\n" + finalPrompt
 	}
 	if finalPrompt == "" {
 		return AgentResult{Ran: false, Output: "", AgentName: name}
@@ -398,6 +407,7 @@ func (r *RunContext) execTemplateAlias(ctx context.Context, agent, alias *agents
 
 func (r *RunContext) execPromptAlias(ctx context.Context, agent, alias *agents.Agent, input string, name string) AgentResult {
 	template := alias.Prompt
+	var obsPrompt string
 	if agent.Role != "" {
 		role, ok := r.Registry.LookupRole(agent.Role)
 		if ok && role.Personality != "" || role.Performance != "" {
@@ -411,10 +421,18 @@ func (r *RunContext) execPromptAlias(ctx context.Context, agent, alias *agents.A
 				template = fmt.Sprintf("%s\n\nYou Are Playing: %s\n%s%s", template, role.ID, personality, performance)
 			}
 		}
+		var err error
+		obsPrompt, err = r.processObservations(ctx, agent, input)
+		if err != nil {
+			r.Errorf("observation processing error: %v", err)
+		}
 	}
 	finalPrompt, err := r.renderFinalPrompt(ctx, template, agent, input)
 	if err != nil {
 		return AgentResult{Ran: false, Error: err, AgentName: name}
+	}
+	if obsPrompt != "" {
+		finalPrompt = obsPrompt + "\n\n" + finalPrompt
 	}
 	if finalPrompt == "" {
 		return AgentResult{Ran: false, Output: "", AgentName: name}

--- a/run_observations_test.go
+++ b/run_observations_test.go
@@ -1,0 +1,65 @@
+package agencia
+
+import (
+	"context"
+	"testing"
+
+	"github.com/robbyriverside/agencia/agents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessObservations(t *testing.T) {
+	calls := 0
+	observationAICall = func(ctx context.Context, prompt string) (string, error) {
+		calls++
+		if calls == 1 {
+			return `{"writing_pref": ["likes novels"]}`, nil
+		}
+		return `{"writing_pref": ["likes poetry", "likes novels"]}`, nil
+	}
+	defer func() { observationAICall = agents.CallOpenAI }()
+
+	reg := &Registry{Roles: map[string]*agents.AgentRole{
+		"writer": {ID: "writer", Name: "writer", Observations: map[string]string{"writing_pref": "writing preferences"}},
+	}}
+	chat := NewChat("a")
+	chat.AddObservation("writer", "writing_pref", "likes poetry")
+	run := NewRun(reg, chat)
+
+	agent := &agents.Agent{Name: "a", Prompt: "Say hi", Role: "writer"}
+
+	sub, err := run.processObservations(context.Background(), agent, "I enjoy long novels")
+	require.NoError(t, err)
+	obs := chat.ObservationsByRole("writer")
+	require.Len(t, obs["writing_pref"], 2)
+	assert.Contains(t, sub, "likes poetry")
+	assert.Contains(t, sub, "likes novels")
+}
+
+func TestGatherObservationsBadJSON(t *testing.T) {
+	observationAICall = func(ctx context.Context, prompt string) (string, error) {
+		return "not json", nil
+	}
+	defer func() { observationAICall = agents.CallOpenAI }()
+
+	run := &RunContext{}
+	role := &agents.AgentRole{ID: "writer", Name: "writer", Observations: map[string]string{"writing_pref": "prefs"}}
+	_, err := run.gatherObservationsFromInput(context.Background(), role, "I like novels")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not json")
+}
+
+func TestMergeObservationsBadJSON(t *testing.T) {
+	observationAICall = func(ctx context.Context, prompt string) (string, error) {
+		return "{oops", nil
+	}
+	defer func() { observationAICall = agents.CallOpenAI }()
+
+	run := &RunContext{}
+	existing := map[string][]string{"writing_pref": []string{"likes poetry"}}
+	incoming := map[string][]string{"writing_pref": []string{"likes novels"}}
+	_, err := run.mergeObservations(context.Background(), existing, incoming)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "{oops")
+}


### PR DESCRIPTION
## Summary
- gather and merge role observations with AI assistance
- prepend observation context to prompt-based agents and aliases
- add unit test for observation processing
- surface invalid AI JSON with detailed errors and regression tests

## Testing
- `go test -run TestProcessObservations -v`
- `go test -run TestGatherObservationsBadJSON -v`
- `go test -run TestMergeObservationsBadJSON -v`
- `go test ./...` *(fails: OPENAI_API_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68912f84d01c83248b44ccf06c8e7aed